### PR TITLE
fix: #35 グラフのレスポンシブ対応の調整

### DIFF
--- a/src/components/modules/graph/Graph.scss
+++ b/src/components/modules/graph/Graph.scss
@@ -4,14 +4,26 @@
   min-width: 1200px;
 }
 
+.graph-wrapper > .container {
+  width: 500px;
+}
+
 @media (width <= 1280px) {
+  .graph-wrapper {
+    min-width: 768px;
+  }
+
   .graph-wrapper > .container {
-    width: 768px;
+    width: 700px;
   }
 }
 
 @media (width <= 768px) {
   .graph-wrapper {
-    width: 500px;
+    min-width: 600px;
+  }
+
+  .graph-wrapper > .container {
+    width: 560px;
   }
 }

--- a/src/components/pages/prefecturePopulation/PrefecturePopulation.stories.tsx
+++ b/src/components/pages/prefecturePopulation/PrefecturePopulation.stories.tsx
@@ -111,11 +111,11 @@ const meta = {
   component: PrefecturePopulation,
   tags: ["autodocs"],
   parameters: {
-    layout: "centered",
+    layout: "fullscreen",
   },
   decorators: [
     (Story) => (
-      <div style={{ padding: "16px" }}>
+      <div style={{ padding: "32px", maxWidth: "1200px" }}>
         <Story />
       </div>
     ),


### PR DESCRIPTION
closes #35
スマートフォン・タブレットサイズの時にスクロール量を減らすように修正しました。
また、`PrefecturePopulation`コンポーネントのstoryで不用意に横スクロールさせないように対応しました。