### PR TITLE
refactor: #42 mockディレクトリのファイルをコンポーネントに移動した

### DIFF
--- a/src/components/pages/prefecturePopulation/PrefecturePopulation.mock.ts
+++ b/src/components/pages/prefecturePopulation/PrefecturePopulation.mock.ts
@@ -1,14 +1,14 @@
 import { fn } from "@storybook/test";
-import {
-  generatePopulationData,
-  prefectures,
-} from "@/mock/prefecturePopulation";
 import { CheckboxesProps } from "@/components/templates/checkboxes";
+import {
+  generateMockPopulation,
+  mockPrefectures,
+} from "@/components/parts/graph/Graph.mock";
 import { FetchPrefecturePopulationType } from "#useFetchPrefecturePopulation";
 
-const populationData = generatePopulationData(47);
+const mockPopulation = generateMockPopulation(47);
 
-const prefecturePopulation: FetchPrefecturePopulationType = prefectures.map(
+const prefecturePopulation: FetchPrefecturePopulationType = mockPrefectures.map(
   ({ key, name }) => {
     const prefCode = key;
     const prefName = name;
@@ -20,7 +20,7 @@ const prefecturePopulation: FetchPrefecturePopulationType = prefectures.map(
       populationData: [
         {
           label: "総人口",
-          data: populationData.map(({ xValue, yValues }) => ({
+          data: mockPopulation.map(({ xValue, yValues }) => ({
             year: xValue,
             value: yValues[1] * randomFactor + randomStartValue,
             rate: yValues[0] * randomFactor + randomStartValue,
@@ -28,7 +28,7 @@ const prefecturePopulation: FetchPrefecturePopulationType = prefectures.map(
         },
         {
           label: "年少人口",
-          data: populationData.map(({ xValue, yValues }) => ({
+          data: mockPopulation.map(({ xValue, yValues }) => ({
             year: xValue,
             value: yValues[1] * randomFactor + randomStartValue,
             rate: yValues[0] * randomFactor + randomStartValue,
@@ -36,7 +36,7 @@ const prefecturePopulation: FetchPrefecturePopulationType = prefectures.map(
         },
         {
           label: "生産年齢人口",
-          data: populationData.map(({ xValue, yValues }) => ({
+          data: mockPopulation.map(({ xValue, yValues }) => ({
             year: xValue,
             value: yValues[2] * randomFactor + randomStartValue,
             rate: yValues[0] * randomFactor + randomStartValue,
@@ -44,7 +44,7 @@ const prefecturePopulation: FetchPrefecturePopulationType = prefectures.map(
         },
         {
           label: "老年人口",
-          data: populationData.map(({ xValue, yValues }) => ({
+          data: mockPopulation.map(({ xValue, yValues }) => ({
             year: xValue,
             value: yValues[3] * randomFactor + randomStartValue,
             rate: yValues[0] * randomFactor + randomStartValue,

--- a/src/components/pages/prefecturePopulation/PrefecturePopulation.stories.tsx
+++ b/src/components/pages/prefecturePopulation/PrefecturePopulation.stories.tsx
@@ -1,23 +1,26 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { expect, userEvent, within, screen } from "@storybook/test";
 import { PrefecturePopulation } from "./PrefecturePopulation";
-import { labelProps, prefectures } from "@/mock/prefecturePopulation";
+import {
+  mockGraphLabelProps,
+  mockPrefectures,
+} from "@/components/parts/graph/Graph.mock";
 
 const FIRST_PREFECTURE_INDEX = 0;
 const SECOND_PREFECTURE_INDEX = 1;
 
 const verifyLabelsNotDisplayed = async (canvas: ReturnType<typeof within>) => {
   await expect(
-    canvas.queryByText(labelProps.xAxisLabel),
+    canvas.queryByText(mockGraphLabelProps.xAxisLabel),
   ).not.toBeInTheDocument();
   await expect(
-    canvas.queryByText(labelProps.yAxisLabel),
+    canvas.queryByText(mockGraphLabelProps.yAxisLabel),
   ).not.toBeInTheDocument();
 };
 
 const verifyLabelsDisplayed = async (canvas: ReturnType<typeof within>) => {
-  await canvas.findByText(labelProps.xAxisLabel);
-  await canvas.findByText(labelProps.yAxisLabel);
+  await canvas.findByText(mockGraphLabelProps.xAxisLabel);
+  await canvas.findByText(mockGraphLabelProps.yAxisLabel);
 };
 
 const toggleCheckbox = async (
@@ -63,7 +66,7 @@ const testPrefecturePopulation: Story["play"] = async ({
     async () => {
       await toggleCheckbox(canvas, FIRST_PREFECTURE_INDEX, "true");
       await toggleCheckbox(canvas, SECOND_PREFECTURE_INDEX, "true");
-      const selectedPrefectures = prefectures.slice(
+      const selectedPrefectures = mockPrefectures.slice(
         FIRST_PREFECTURE_INDEX,
         SECOND_PREFECTURE_INDEX + 1,
       );
@@ -127,7 +130,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    prefectureCheckboxes: prefectures.map((prefecture) => ({
+    prefectureCheckboxes: mockPrefectures.map((prefecture) => ({
       id: prefecture.key.toString(),
       label: prefecture.name,
     })),

--- a/src/components/parts/graph/Graph.mock.ts
+++ b/src/components/parts/graph/Graph.mock.ts
@@ -1,4 +1,4 @@
-export const prefectures = [
+export const mockPrefectures = [
   { key: 1, name: "北海道" },
   { key: 2, name: "青森県" },
   { key: 3, name: "岩手県" },
@@ -48,15 +48,15 @@ export const prefectures = [
   { key: 47, name: "沖縄県" },
 ];
 
-export const labelProps = {
+export const mockGraphLabelProps = {
   xAxisLabel: "年(年度)",
   yAxisLabel: "人口(人)",
   xTooltipLabel: "年",
   yTooltipLabel: "人",
 };
 
-export const getPrefectures = (count: number) =>
-  prefectures
+export const getMockPrefectures = (count: number) =>
+  mockPrefectures
     .map((prefecture) => {
       return {
         key: String(prefecture.key),
@@ -65,9 +65,9 @@ export const getPrefectures = (count: number) =>
     })
     .slice(0, count);
 
-export const generatePopulationData = (count: number) => {
+export const generateMockPopulation = (count: number) => {
   const years = Array.from({ length: 2045 - 1965 + 1 }, (_, i) => 1965 + i);
-  const selectedPrefectures = getPrefectures(count);
+  const selectedPrefectures = getMockPrefectures(count);
   return years.map((year, index) => ({
     xValue: year,
     yValues: selectedPrefectures.reduce(

--- a/src/components/parts/graph/Graph.stories.tsx
+++ b/src/components/parts/graph/Graph.stories.tsx
@@ -3,17 +3,17 @@ import { within, expect, screen } from "@storybook/test";
 import { StepFunction } from "@storybook/core/types";
 import { Graph } from "./Graph";
 import {
-  generatePopulationData,
-  getPrefectures,
-  labelProps,
-  prefectures,
-} from "@/mock/prefecturePopulation";
+  generateMockPopulation,
+  getMockPrefectures,
+  mockGraphLabelProps,
+  mockPrefectures,
+} from "./Graph.mock";
 
 const testGraphLabels: Story["play"] = async ({ canvasElement, step }) => {
   const canvas = within(canvasElement);
   await step("ラベルが正しく表示されていることを確認", async () => {
-    await canvas.findByText(labelProps.xAxisLabel);
-    await canvas.findByText(labelProps.yAxisLabel);
+    await canvas.findByText(mockGraphLabelProps.xAxisLabel);
+    await canvas.findByText(mockGraphLabelProps.yAxisLabel);
   });
 };
 
@@ -29,21 +29,21 @@ const testPrefectureNames = async (
 };
 
 const testSinglePrefecture: Story["play"] = async ({ step }) => {
-  const prefectureNames = getPrefectures(1).map(
+  const prefectureNames = getMockPrefectures(1).map(
     (prefecture) => prefecture.name,
   );
   await testPrefectureNames(step, prefectureNames);
 };
 
 const testTenPrefectures: Story["play"] = async ({ step }) => {
-  const prefectureNames = getPrefectures(10).map(
+  const prefectureNames = getMockPrefectures(10).map(
     (prefecture) => prefecture.name,
   );
   await testPrefectureNames(step, prefectureNames);
 };
 
 const testAllPrefectures: Story["play"] = async ({ step }) => {
-  const prefectureNames = prefectures.map((prefecture) => prefecture.name);
+  const prefectureNames = mockPrefectures.map((prefecture) => prefecture.name);
   await testPrefectureNames(step, prefectureNames);
 };
 
@@ -61,9 +61,9 @@ type Story = StoryObj<typeof meta>;
 
 export const Data1: Story = {
   args: {
-    data: generatePopulationData(1),
-    lines: getPrefectures(1),
-    ...labelProps,
+    data: generateMockPopulation(1),
+    lines: getMockPrefectures(1),
+    ...mockGraphLabelProps,
   },
   play: async (context) => {
     await testGraphLabels(context);
@@ -73,9 +73,9 @@ export const Data1: Story = {
 
 export const Data10: Story = {
   args: {
-    data: generatePopulationData(10),
-    lines: getPrefectures(10),
-    ...labelProps,
+    data: generateMockPopulation(10),
+    lines: getMockPrefectures(10),
+    ...mockGraphLabelProps,
   },
   play: async (context) => {
     await testGraphLabels(context);
@@ -85,9 +85,9 @@ export const Data10: Story = {
 
 export const Data47: Story = {
   args: {
-    data: generatePopulationData(47),
-    lines: getPrefectures(47),
-    ...labelProps,
+    data: generateMockPopulation(47),
+    lines: getMockPrefectures(47),
+    ...mockGraphLabelProps,
   },
   play: async (context) => {
     await testGraphLabels(context);

--- a/src/components/templates/graphTabs/GraphTabs.stories.tsx
+++ b/src/components/templates/graphTabs/GraphTabs.stories.tsx
@@ -2,10 +2,10 @@ import { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within, expect } from "@storybook/test";
 import { GraphTabs } from "./GraphTabs";
 import {
-  generatePopulationData,
-  getPrefectures,
-  labelProps,
-} from "@/mock/prefecturePopulation";
+  generateMockPopulation,
+  getMockPrefectures,
+  mockGraphLabelProps,
+} from "@/components/parts/graph/Graph.mock";
 
 const meta = {
   title: "Template/GraphTabs",
@@ -30,8 +30,8 @@ const testGraphLabels: Story["play"] = async ({ canvasElement, step }) => {
   const canvas = within(canvasElement);
   const [firstTab, secondTab] = canvas.getAllByRole("tab");
   await step("ラベルが正しく表示されていることを確認", async () => {
-    await canvas.findByText(labelProps.xAxisLabel);
-    await canvas.findByText(labelProps.yAxisLabel);
+    await canvas.findByText(mockGraphLabelProps.xAxisLabel);
+    await canvas.findByText(mockGraphLabelProps.yAxisLabel);
   });
 
   const initialPanel = canvas.getByRole("tabpanel");
@@ -58,12 +58,12 @@ const testGraphLabels: Story["play"] = async ({ canvasElement, step }) => {
 export const Default: Story = {
   args: {
     graphData: {
-      tab1: [...generatePopulationData(3)],
-      tab2: [...generatePopulationData(3)],
-      tab3: [...generatePopulationData(3)],
+      tab1: [...generateMockPopulation(3)],
+      tab2: [...generateMockPopulation(3)],
+      tab3: [...generateMockPopulation(3)],
     },
-    lines: getPrefectures(3),
-    ...labelProps,
+    lines: getMockPrefectures(3),
+    ...mockGraphLabelProps,
   },
   play: testGraphLabels,
 };


### PR DESCRIPTION
closes #42 

storybookで使う都道府県mockデータをsrc/mockディレクトリから`src/components/parts/graph`に移動しました。
理由は`src/components/pages/prefecturePopulation`ディレクトリの中に`PrefecturePopulation.mock.ts`のmockデータが存在するのでこの方法記述方法に統一させるためです。
