### PR TITLE
refactor: #47 Storybookの並び順をコンポーネントサイズが小さい順に変更した

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -8,6 +8,11 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
+    options: {
+      storySort: {
+        order: ['Parts', 'Templates', 'Pages'],
+      },
+    },
   },
 };
 

--- a/src/components/templates/checkboxes/Checkboxes.stories.tsx
+++ b/src/components/templates/checkboxes/Checkboxes.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Checkboxes } from "./Checkboxes";
 
 const meta = {
-  title: "Template/Checkboxes",
+  title: "Templates/Checkboxes",
   component: Checkboxes,
   tags: ["autodocs"],
   parameters: {

--- a/src/components/templates/graphTabs/GraphTabs.stories.tsx
+++ b/src/components/templates/graphTabs/GraphTabs.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/parts/graph/Graph.mock";
 
 const meta = {
-  title: "Template/GraphTabs",
+  title: "Templates/GraphTabs",
   component: GraphTabs,
   tags: ["autodocs"],
   parameters: {

--- a/src/components/templates/layout/Layout.stories.tsx
+++ b/src/components/templates/layout/Layout.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Layout } from "./Layout";
 
 const meta = {
-  title: "Template/Layout",
+  title: "Templates/Layout",
   component: Layout,
   tags: ["autodocs"],
   parameters: {


### PR DESCRIPTION
現状、Storybookではコンポーネントがアルファベット順に並んでいるため、Pages、Parts、Templatesの関係性がわかりにくいという問題がありました。
コンポーネントの規模を明確にするため、Parts→Templates→Pagesの順に変更し、小さいものから大きいものへと並べ替えました。