### PR TITLE
fix: #52 チェックボックスをキーボード操作した時のスタイルを改善した

### DIFF
--- a/src/components/parts/checkbox/Checkbox.scss
+++ b/src/components/parts/checkbox/Checkbox.scss
@@ -27,8 +27,12 @@
   @extend .checkbox;
 
   background-color: $primary;
-  color: $secondary;
   border: 1px solid $primary;
+}
+
+.checkbox-wrapper > .unchecked:focus-visible {
+  outline: 2px solid rgba($primary, 0.5);
+  outline-offset: 2px;
 }
 
 .checkbox-wrapper > .checkbox > .mark {

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -3,4 +3,3 @@ $black: #171717;
 $gray: #e0e0e0;
 $light-gray: #f7f7f7;
 $primary: #38b;
-$secondary: #00f;


### PR DESCRIPTION
closes #52 
チェックボックスのフォーカス時の枠線を太くしました。
チェック済みのチェックボックスとフォーカスのスタイルの違いをわかりやすくするためです