### PR TITLE
fix: #54 Storybookでチェックボックスを並べた時、横並びにならない不具合の修正対応

### DIFF
--- a/src/components/templates/checkboxes/Checkboxes.scss
+++ b/src/components/templates/checkboxes/Checkboxes.scss
@@ -1,19 +1,14 @@
 .checkboxes-wrapper {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
   gap: 0.5rem;
 }
 
 .checkboxes-horizontal {
   @extend .checkboxes-wrapper;
 
-  flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: center;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
 }
 
 .checkboxes-vertical {
   @extend .checkboxes-wrapper;
-
-  flex-direction: column;
 }

--- a/src/components/templates/checkboxes/Checkboxes.stories.tsx
+++ b/src/components/templates/checkboxes/Checkboxes.stories.tsx
@@ -6,9 +6,13 @@ const meta = {
   title: "Templates/Checkboxes",
   component: Checkboxes,
   tags: ["autodocs"],
-  parameters: {
-    layout: "centered",
-  },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: "32px" }}>
+        <Story />
+      </div>
+    ),
+  ],
 } satisfies Meta<typeof Checkboxes>;
 
 export default meta;


### PR DESCRIPTION
closes #54 

プロダクト上は問題ないが、Storybookでチェックボックスを並べた時、横並びにならない不具合の対応。
おそらくdisplay: gridを使っているのでFlexboxを使わない方向で実装しました。